### PR TITLE
boolean now maps to tinyint (which is aliased by bool in mysql) rather t...

### DIFF
--- a/mvc/Page/SchemaGenerator.php
+++ b/mvc/Page/SchemaGenerator.php
@@ -137,7 +137,7 @@ class Page_SchemaGenerator extends Page {
             "date" => "date",
             "password" => "varchar(255)",
             "text" => "text",
-            "boolean" => "enum('Y','N')",
+            "boolean" => "tinyint(1)",
             "default" => "varchar(255)"
         );
         $special = array(


### PR DESCRIPTION
...han enum(Y,N)

enum(Y,N) was causing bugs with form elements: https://github.com/atk4/atk4/pull/63
